### PR TITLE
fix: use zot tag in ui make target

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,10 +1,10 @@
 on:
   push:
     branches:
-      - main
+      - ui-integration-laurentiu
   pull_request:
     branches:
-      - main
+      - ui-integration-laurentiu
   release:
     types:
       - published

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,6 +49,19 @@ jobs:
           go-version: 1.19.x
       - name: Check out source code
         uses: actions/checkout@v3
+
+      - name: Push release tag to zui
+        if: github.event_name == 'release' && github.event.action == 'published' && matrix.os == 'linux' && matrix.arch == 'amd64'
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.ZUI_TOKEN }}
+          repo: zui
+          owner: project-zot
+          tag: ${{ github.event.release.tag_name }}
+          name: ${{ github.event.release.name }}
+          body: ${{ github.event.release.body }}
+          commit: main
+
       - name: Cache go dependencies
         id: cache-go-dependencies
         uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,11 @@ ui:
 	pwd=$$(pwd);\
 	tdir=$$(mktemp -d);\
 	cd $$tdir;\
-	git clone https://github.com/project-zot/zui.git;\
+	if [ -z $(RELEASE_UI) ]; then\
+		git clone https://github.com/project-zot/zui.git;\
+	else\
+		git clone --depth 1 --branch $(RELEASE_TAG) https://github.com/project-zot/zui.git;\
+	fi;\
 	cd zui;\
 	npm install;\
 	npm run build;\


### PR DESCRIPTION
Added workflow that runs on a new zot release, pushing the tag to the zui repo
Modified make ui to checkout the above tag branch from zui for building

Fixes https://github.com/project-zot/zot/issues/926

At the time of writing, 3bb2e08 was the lastest commit on zui, and a2cd96b was the commit used in the release.
```
chofnar@CSCO-W-PF424C2C:~/github/zot (ui-integration-chofnar-releasetag)$ make ui
pwd=$(pwd);\
tdir=$(mktemp -d);\
cd $tdir;\
if [ -z  ]; then\
        git clone https://github.com/chofnar/zui.git;\
else\
        git clone --depth 1 --branch zot-zui-release11 https://github.com/chofnar/zui.git;\
fi;\
cd zui;\
npm install;\
npm run build;\
cd $pwd;\
rm -rf ./pkg/extensions/build;\
cp -R $tdir/zui/build ./pkg/extensions/;
Cloning into 'zui'...
remote: Enumerating objects: 1409, done.
remote: Counting objects: 100% (1409/1409), done.
remote: Compressing objects: 100% (391/391), done.
remote: Total 1409 (delta 1025), reused 1354 (delta 1014), pack-reused 0
Receiving objects: 100% (1409/1409), 10.78 MiB | 7.46 MiB/s, done.
Resolving deltas: 100% (1025/1025), done.
/bin/sh: 10: npm: not found
/bin/sh: 11: npm: not found
cp: cannot stat '/tmp/tmp.TBI1XSM0Pv/zui/build': No such file or directory
make: *** [Makefile:361: ui] Error 1
chofnar@CSCO-W-PF424C2C:~/github/zot (ui-integration-chofnar-releasetag)$ cd /tmp/tmp.TBI1XSM0Pv/zui
chofnar@CSCO-W-PF424C2C:/tmp/tmp.TBI1XSM0Pv/zui (main)$ git status
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
chofnar@CSCO-W-PF424C2C:/tmp/tmp.TBI1XSM0Pv/zui (main)$ git log --oneline
3bb2e08 (HEAD -> main, origin/main, origin/HEAD) Added failed scan chip
a2cd96b (tag: zot-zui-release11) Most popular title changes
907d021 feat: Added filter for tags tab




chofnar@CSCO-W-PF424C2C:~/github/zot (ui-integration-chofnar-releasetag)$ RELEASE_UI="true" make ui
pwd=$(pwd);\
tdir=$(mktemp -d);\
cd $tdir;\
if [ -z true ]; then\
        git clone https://github.com/chofnar/zui.git;\
else\
        git clone --depth 1 --branch zot-zui-release11 https://github.com/chofnar/zui.git;\
fi;\
cd zui;\
npm install;\
npm run build;\
cd $pwd;\
rm -rf ./pkg/extensions/build;\
cp -R $tdir/zui/build ./pkg/extensions/;
Cloning into 'zui'...
remote: Enumerating objects: 129, done.
remote: Counting objects: 100% (129/129), done.
remote: Compressing objects: 100% (128/128), done.
remote: Total 129 (delta 16), reused 59 (delta 1), pack-reused 0
Receiving objects: 100% (129/129), 5.42 MiB | 10.74 MiB/s, done.
Resolving deltas: 100% (16/16), done.
Note: switching to 'a2cd96b71b53aa9e0bbe2af4e2332eaa6704d853'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

/bin/sh: 10: npm: not found
/bin/sh: 11: npm: not found
cp: cannot stat '/tmp/tmp.vXaX54e3sc/zui/build': No such file or directory
make: *** [Makefile:361: ui] Error 1
chofnar@CSCO-W-PF424C2C:~/github/zot (ui-integration-chofnar-releasetag)$ cd /tmp/tmp.vXaX54e3sc/zui
chofnar@CSCO-W-PF424C2C:/tmp/tmp.vXaX54e3sc/zui ((no branch))$ git log --oneline
a2cd96b (grafted, HEAD, tag: zot-zui-release11) Most popular title changes
```

Signed-off-by: Catalin Hofnar <catalin.hofnar@gmail.com>